### PR TITLE
Filter order and uniqueness

### DIFF
--- a/core/src/main/java/io/varhttp/FilterTuple.java
+++ b/core/src/main/java/io/varhttp/FilterTuple.java
@@ -20,18 +20,24 @@ public class FilterTuple {
 		return annotation;
 	}
 
+
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
 
-		Class<?> otherValue = ((FilterTuple) o).filter.value();
-		Class<?> value = filter.value();
-		return Objects.equals(value, otherValue);
+		FilterTuple that = (FilterTuple) o;
+
+		if (!Objects.equals(filter.value(), that.filter.value())) return false;
+		return Objects.equals(annotation.getClass(), that.annotation.getClass());
 	}
 
 	@Override
 	public int hashCode() {
-		return filter.value().hashCode();
+		int result = filter.value() != null ? filter.value().hashCode() : 0;
+		result = 31 * result + (annotation.getClass() != null ? annotation.getClass().hashCode() : 0);
+		return result;
 	}
 }

--- a/core/src/main/java/io/varhttp/Standalone.java
+++ b/core/src/main/java/io/varhttp/Standalone.java
@@ -4,6 +4,8 @@ import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsParameters;
 import com.sun.net.httpserver.HttpsServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -41,6 +43,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class Standalone implements Runnable {
+	private static Logger logger = LoggerFactory.getLogger(Standalone.class);
 	private CompletableFuture<Boolean> started = new CompletableFuture<>();
 	protected VarServlet servlet;
 
@@ -169,7 +172,7 @@ public class Standalone implements Runnable {
 		server.setExecutor(Executors.newCachedThreadPool());
 		server.start();
 		started.complete(true);
-		System.out.println("Started completely");
+		logger.info("var-http started");
 	}
 
 	public void stop() {

--- a/core/src/main/java/io/varhttp/VarConfiguration.java
+++ b/core/src/main/java/io/varhttp/VarConfiguration.java
@@ -4,6 +4,8 @@ import io.varhttp.parameterhandlers.IParameterHandlerMatcher;
 
 import javax.servlet.Filter;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class VarConfiguration {
@@ -12,6 +14,8 @@ public class VarConfiguration {
 	private ControllerMapper controllerMapper = null;
 	private final ParameterHandler parameterHandler;
 	private ExceptionRegistry exceptionRegistry;
+	List<Runnable> mappings = new ArrayList<>();
+
 
 	public VarConfiguration(VarServlet servlet, ControllerMapper controllerMapper, VarConfigurationContext context, ParameterHandler parameterHandler) {
 		this.servlet = servlet;
@@ -21,11 +25,15 @@ public class VarConfiguration {
 	}
 
 	public void addControllerPackage(Package controllerPackage) {
-		controllerMapper.map(context, controllerPackage.getName());
+		mappings.add(() -> {
+			controllerMapper.map(context, controllerPackage.getName());
+		});
 	}
 
 	public void addController(Class<?> controller) {
-		controllerMapper.map(context, controller);
+		mappings.add(() -> {
+			controllerMapper.map(context, controller);
+		});
 	}
 
 	public void setControllerFactory(ControllerFactory controllerFactory) {
@@ -69,7 +77,15 @@ public class VarConfiguration {
 		servlet.executions.createPathContext(context, basePath);
 	}
 
-	public void configure(Consumer<VarConfiguration> configuration) {
-		configuration.accept(new VarConfiguration(servlet, controllerMapper, new VarConfigurationContext(servlet, context, parameterHandler), parameterHandler));
+	public void configure(Consumer<VarConfiguration> configurationConsumer) {
+		VarConfigurationContext newContext = new VarConfigurationContext(servlet, context, parameterHandler);
+		VarConfiguration configuration = new VarConfiguration(servlet, controllerMapper, newContext, parameterHandler);
+		configurationConsumer.accept(configuration);
+		newContext.applyMappings();
+		configuration.applyMappings();
+	}
+
+	public void applyMappings() {
+		mappings.forEach(Runnable::run);
 	}
 }

--- a/core/src/main/java/io/varhttp/VarConfigurationContext.java
+++ b/core/src/main/java/io/varhttp/VarConfigurationContext.java
@@ -73,7 +73,7 @@ public class VarConfigurationContext {
 
 
 	List<Object> getDefaultFilters() {
-		return Stream.concat(defaultFilters.stream(),parentContext.getDefaultFilters().stream()).collect(Collectors.toList());
+		return Stream.concat(parentContext.getDefaultFilters().stream(), defaultFilters.stream()).collect(Collectors.toList());
 	}
 
 	public void addExecution(Class<?> controllerClass, Method method, String baseUri, String classPath, ControllerMatch matchResult, VarConfigurationContext context) {

--- a/core/src/main/java/io/varhttp/VarFilter.java
+++ b/core/src/main/java/io/varhttp/VarFilter.java
@@ -3,6 +3,6 @@ package io.varhttp;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
-public interface VarFilter extends javax.servlet.Filter {
+public interface VarFilter {
 	void init(Method method, io.varhttp.Filter f, Annotation annotation);
 }

--- a/core/src/main/java/io/varhttp/VarHttpContext.java
+++ b/core/src/main/java/io/varhttp/VarHttpContext.java
@@ -95,19 +95,4 @@ public class VarHttpContext implements HttpHandler {
 		}
 		return out.toByteArray();
 	}
-
-	@SuppressWarnings("unchecked")
-	private static <T> T createUnimplementAdapter(Class<T> httpServletApi) {
-		class UnimplementedHandler implements InvocationHandler {
-			@Override
-			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-				System.out.println("Not implemented: " + method + ", args=" + Arrays.toString(args));
-				throw new UnsupportedOperationException("Not implemented: " + method + ", args=" + Arrays.toString(args));
-			}
-		}
-
-		return (T) Proxy.newProxyInstance(UnimplementedHandler.class.getClassLoader(),
-				new Class<?>[] { httpServletApi },
-				new UnimplementedHandler());
-	}
 }

--- a/core/src/main/java/io/varhttp/VarServlet.java
+++ b/core/src/main/java/io/varhttp/VarServlet.java
@@ -96,6 +96,9 @@ public class VarServlet extends HttpServlet {
 	}
 
 	public void configure(Consumer<VarConfiguration> configuration) {
-		configuration.accept(new VarConfiguration(this, controllerMapper, baseConfigurationContext, parameterHandler));
+		VarConfiguration varConfiguration = new VarConfiguration(this, controllerMapper, baseConfigurationContext, parameterHandler);
+		configuration.accept(varConfiguration);
+		baseConfigurationContext.applyMappings();
+		varConfiguration.applyMappings();
 	}
 }

--- a/test/src/main/java/io/varhttp/controllers/withfilters/AuthorizationFilter.java
+++ b/test/src/main/java/io/varhttp/controllers/withfilters/AuthorizationFilter.java
@@ -1,9 +1,9 @@
 package io.varhttp.controllers.withfilters;
 
-import io.varhttp.Filter;
 import io.varhttp.VarFilter;
 
 import javax.inject.Inject;
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
-public class AuthorizationFilter implements VarFilter {
+public class AuthorizationFilter implements Filter, VarFilter {
 	private Role role;
 	private FilterCatcher filterCatcher;
 
@@ -28,7 +28,7 @@ public class AuthorizationFilter implements VarFilter {
 	}
 
 	@Override
-	public void init(Method method, Filter f, Annotation annotation) {
+	public void init(Method method, io.varhttp.Filter f, Annotation annotation) {
 		this.role = ((Authorization)annotation).value();
 	}
 }

--- a/test/src/main/java/io/varhttp/controllers/withfilters/LoggingFilter.java
+++ b/test/src/main/java/io/varhttp/controllers/withfilters/LoggingFilter.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
-public class LoggingFilter implements VarFilter {
+public class LoggingFilter implements VarFilter, javax.servlet.Filter {
 	private FilterCatcher filterCatcher;
 
 	@Inject

--- a/test/src/main/java/io/varhttp/filterorder/ClassFilter1.java
+++ b/test/src/main/java/io/varhttp/filterorder/ClassFilter1.java
@@ -1,0 +1,15 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.RUNTIME)
+@Filter(OrderFilter.class)
+public @interface ClassFilter1 {
+	int value();
+}

--- a/test/src/main/java/io/varhttp/filterorder/ClassFilter1.java
+++ b/test/src/main/java/io/varhttp/filterorder/ClassFilter1.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Filter(OrderFilter.class)
 public @interface ClassFilter1 {
-	int value();
 }

--- a/test/src/main/java/io/varhttp/filterorder/ClassFilter2.java
+++ b/test/src/main/java/io/varhttp/filterorder/ClassFilter2.java
@@ -1,0 +1,15 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.RUNTIME)
+@Filter(OrderFilter.class)
+public @interface ClassFilter2 {
+	int value();
+}

--- a/test/src/main/java/io/varhttp/filterorder/ClassFilter2.java
+++ b/test/src/main/java/io/varhttp/filterorder/ClassFilter2.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Filter(OrderFilter.class)
 public @interface ClassFilter2 {
-	int value();
 }

--- a/test/src/main/java/io/varhttp/filterorder/DefaultFilter1.java
+++ b/test/src/main/java/io/varhttp/filterorder/DefaultFilter1.java
@@ -1,0 +1,13 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.controllers.withfilters.FilterCatcher;
+
+import javax.inject.Inject;
+
+public class DefaultFilter1 extends OrderFilter {
+	@Inject
+	public DefaultFilter1(FilterCatcher filterCatcher) {
+		super(filterCatcher);
+		order = getClass().getSimpleName();
+	}
+}

--- a/test/src/main/java/io/varhttp/filterorder/DefaultFilter2.java
+++ b/test/src/main/java/io/varhttp/filterorder/DefaultFilter2.java
@@ -1,0 +1,13 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.controllers.withfilters.FilterCatcher;
+
+import javax.inject.Inject;
+
+public class DefaultFilter2 extends OrderFilter {
+	@Inject
+	public DefaultFilter2(FilterCatcher filterCatcher) {
+		super(filterCatcher);
+		order = getClass().getSimpleName();
+	}
+}

--- a/test/src/main/java/io/varhttp/filterorder/DefaultFilter3.java
+++ b/test/src/main/java/io/varhttp/filterorder/DefaultFilter3.java
@@ -1,0 +1,13 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.controllers.withfilters.FilterCatcher;
+
+import javax.inject.Inject;
+
+public class DefaultFilter3 extends OrderFilter {
+	@Inject
+	public DefaultFilter3(FilterCatcher filterCatcher) {
+		super(filterCatcher);
+		order = getClass().getSimpleName();
+	}
+}

--- a/test/src/main/java/io/varhttp/filterorder/DefaultFilter4.java
+++ b/test/src/main/java/io/varhttp/filterorder/DefaultFilter4.java
@@ -1,0 +1,13 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.controllers.withfilters.FilterCatcher;
+
+import javax.inject.Inject;
+
+public class DefaultFilter4 extends OrderFilter {
+	@Inject
+	public DefaultFilter4(FilterCatcher filterCatcher) {
+		super(filterCatcher);
+		order = getClass().getSimpleName();
+	}
+}

--- a/test/src/main/java/io/varhttp/filterorder/FilterControllerClass.java
+++ b/test/src/main/java/io/varhttp/filterorder/FilterControllerClass.java
@@ -7,9 +7,9 @@ import io.varhttp.controllers.withfilters.FilterCatcher;
 
 import javax.inject.Inject;
 
-@ClassFilter1(20)
-@ClassFilter2(21)
-@OverridingFilter(22)
+@ClassFilter1
+@ClassFilter2
+@OverridingFilter
 @ControllerClass
 public class FilterControllerClass {
 	private FilterCatcher filterCatcher;
@@ -20,9 +20,9 @@ public class FilterControllerClass {
 	}
 
 	@Controller(path = "/filter-order", httpMethods = HttpMethod.GET)
-	@MethodFilter1(30)
-	@MethodFilter2(31)
-	@OverridingFilter(32)
+	@MethodFilter1
+	@MethodFilter2
+	@OverridingFilter
 	public void filterOrder() {
 		filterCatcher.add("controller");
 	}

--- a/test/src/main/java/io/varhttp/filterorder/FilterControllerClass.java
+++ b/test/src/main/java/io/varhttp/filterorder/FilterControllerClass.java
@@ -1,0 +1,29 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Controller;
+import io.varhttp.ControllerClass;
+import io.varhttp.HttpMethod;
+import io.varhttp.controllers.withfilters.FilterCatcher;
+
+import javax.inject.Inject;
+
+@ClassFilter1(20)
+@ClassFilter2(21)
+@OverridingFilter(22)
+@ControllerClass
+public class FilterControllerClass {
+	private FilterCatcher filterCatcher;
+
+	@Inject
+	public FilterControllerClass(FilterCatcher filterCatcher) {
+		this.filterCatcher = filterCatcher;
+	}
+
+	@Controller(path = "/filter-order", httpMethods = HttpMethod.GET)
+	@MethodFilter1(30)
+	@MethodFilter2(31)
+	@OverridingFilter(32)
+	public void filterOrder() {
+		filterCatcher.add("controller");
+	}
+}

--- a/test/src/main/java/io/varhttp/filterorder/MethodFilter1.java
+++ b/test/src/main/java/io/varhttp/filterorder/MethodFilter1.java
@@ -1,0 +1,15 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.RUNTIME)
+@Filter(OrderFilter.class)
+public @interface MethodFilter1 {
+	int value();
+}

--- a/test/src/main/java/io/varhttp/filterorder/MethodFilter1.java
+++ b/test/src/main/java/io/varhttp/filterorder/MethodFilter1.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Filter(OrderFilter.class)
 public @interface MethodFilter1 {
-	int value();
 }

--- a/test/src/main/java/io/varhttp/filterorder/MethodFilter2.java
+++ b/test/src/main/java/io/varhttp/filterorder/MethodFilter2.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Filter(OrderFilter.class)
 public @interface MethodFilter2 {
-	int value();
 }

--- a/test/src/main/java/io/varhttp/filterorder/MethodFilter2.java
+++ b/test/src/main/java/io/varhttp/filterorder/MethodFilter2.java
@@ -1,0 +1,15 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.RUNTIME)
+@Filter(OrderFilter.class)
+public @interface MethodFilter2 {
+	int value();
+}

--- a/test/src/main/java/io/varhttp/filterorder/OrderFilter.java
+++ b/test/src/main/java/io/varhttp/filterorder/OrderFilter.java
@@ -1,0 +1,34 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Filter;
+import io.varhttp.FilterMethod;
+import io.varhttp.VarFilter;
+import io.varhttp.VarFilterChain;
+import io.varhttp.controllers.withfilters.FilterCatcher;
+
+import javax.inject.Inject;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+public class OrderFilter implements VarFilter {
+	private FilterCatcher filterCatcher;
+	protected String order;
+
+
+	@Inject
+	public OrderFilter(FilterCatcher filterCatcher) {
+		this.filterCatcher = filterCatcher;
+	}
+
+	@FilterMethod
+	public void filter(VarFilterChain filterChain) throws Exception {
+		filterCatcher.add("in;"+ order);
+		filterChain.proceed();
+		filterCatcher.add("out;"+ order);
+	}
+
+	@Override
+	public void init(Method method, Filter f, Annotation annotation) {
+		order = annotation.annotationType().getSimpleName();
+	}
+}

--- a/test/src/main/java/io/varhttp/filterorder/OverridingFilter.java
+++ b/test/src/main/java/io/varhttp/filterorder/OverridingFilter.java
@@ -1,0 +1,15 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.RUNTIME)
+@Filter(OrderFilter.class)
+public @interface OverridingFilter {
+	int value();
+}

--- a/test/src/main/java/io/varhttp/filterorder/OverridingFilter.java
+++ b/test/src/main/java/io/varhttp/filterorder/OverridingFilter.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Filter(OrderFilter.class)
 public @interface OverridingFilter {
-	int value();
 }

--- a/test/src/main/java/io/varhttp/filterorder/PackageFilter1.java
+++ b/test/src/main/java/io/varhttp/filterorder/PackageFilter1.java
@@ -1,0 +1,15 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.RUNTIME)
+@Filter(OrderFilter.class)
+public @interface PackageFilter1 {
+	int value();
+}

--- a/test/src/main/java/io/varhttp/filterorder/PackageFilter1.java
+++ b/test/src/main/java/io/varhttp/filterorder/PackageFilter1.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Filter(OrderFilter.class)
 public @interface PackageFilter1 {
-	int value();
 }

--- a/test/src/main/java/io/varhttp/filterorder/PackageFilter2.java
+++ b/test/src/main/java/io/varhttp/filterorder/PackageFilter2.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Filter(OrderFilter.class)
 public @interface PackageFilter2 {
-	int value();
 }

--- a/test/src/main/java/io/varhttp/filterorder/PackageFilter2.java
+++ b/test/src/main/java/io/varhttp/filterorder/PackageFilter2.java
@@ -1,0 +1,15 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.Filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.RUNTIME)
+@Filter(OrderFilter.class)
+public @interface PackageFilter2 {
+	int value();
+}

--- a/test/src/main/java/io/varhttp/filterorder/ShouldNotBeRunFilterInner.java
+++ b/test/src/main/java/io/varhttp/filterorder/ShouldNotBeRunFilterInner.java
@@ -1,0 +1,13 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.controllers.withfilters.FilterCatcher;
+
+import javax.inject.Inject;
+
+public class ShouldNotBeRunFilterInner extends OrderFilter {
+	@Inject
+	public ShouldNotBeRunFilterInner(FilterCatcher filterCatcher) {
+		super(filterCatcher);
+		order = getClass().getSimpleName();
+	}
+}

--- a/test/src/main/java/io/varhttp/filterorder/ShouldNotBeRunFilterOnTheSide.java
+++ b/test/src/main/java/io/varhttp/filterorder/ShouldNotBeRunFilterOnTheSide.java
@@ -1,0 +1,13 @@
+package io.varhttp.filterorder;
+
+import io.varhttp.controllers.withfilters.FilterCatcher;
+
+import javax.inject.Inject;
+
+public class ShouldNotBeRunFilterOnTheSide extends OrderFilter {
+	@Inject
+	public ShouldNotBeRunFilterOnTheSide(FilterCatcher filterCatcher) {
+		super(filterCatcher);
+		order = getClass().getSimpleName();
+	}
+}

--- a/test/src/main/java/io/varhttp/filterorder/package-info.java
+++ b/test/src/main/java/io/varhttp/filterorder/package-info.java
@@ -1,0 +1,5 @@
+@PackageFilter1(10)
+@PackageFilter2(11)
+@OverridingFilter(12)
+package io.varhttp.filterorder;
+

--- a/test/src/main/java/io/varhttp/filterorder/package-info.java
+++ b/test/src/main/java/io/varhttp/filterorder/package-info.java
@@ -1,5 +1,5 @@
-@PackageFilter1(10)
-@PackageFilter2(11)
-@OverridingFilter(12)
+@PackageFilter1
+@PackageFilter2
+@OverridingFilter
 package io.varhttp.filterorder;
 

--- a/test/src/test/java/io/varhttp/FilterOrderTest.java
+++ b/test/src/test/java/io/varhttp/FilterOrderTest.java
@@ -37,9 +37,9 @@ public class FilterOrderTest {
 					// This filter should not be run for FilterControllerClass as it is in an inner configurataion
 					configFurtherIn.addDefaultVarFilter(ShouldNotBeRunFilterInner.class);
 				});
-				config.addDefaultVarFilter(DefaultFilter3.class);
-				config.addControllerPackage(FilterControllerClass.class.getPackage());
-				config.addDefaultVarFilter(DefaultFilter4.class);
+				configInner.addDefaultVarFilter(DefaultFilter3.class);
+				configInner.addControllerPackage(FilterControllerClass.class.getPackage());
+				configInner.addDefaultVarFilter(DefaultFilter4.class);
 			});
 			config.configure(configOnTheSide -> {
 				// This filter should not be run for FilterControllerClass as it is in an configurataion next to

--- a/test/src/test/java/io/varhttp/FilterOrderTest.java
+++ b/test/src/test/java/io/varhttp/FilterOrderTest.java
@@ -1,0 +1,92 @@
+package io.varhttp;
+
+import io.odinjector.OdinJector;
+import io.varhttp.filterorder.DefaultFilter1;
+import io.varhttp.filterorder.DefaultFilter2;
+import io.varhttp.filterorder.DefaultFilter3;
+import io.varhttp.filterorder.DefaultFilter4;
+import io.varhttp.controllers.withfilters.FilterCatcher;
+import io.varhttp.filterorder.FilterControllerClass;
+import io.varhttp.filterorder.ShouldNotBeRunFilterInner;
+import io.varhttp.filterorder.ShouldNotBeRunFilterOnTheSide;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class FilterOrderTest {
+	static Standalone launcher;
+	static Thread thread;
+	private static FilterCatcher filterCatcher;
+
+	@BeforeClass
+	public static void setup() {
+		OdinJector odinJector = OdinJector.create().addContext(new OdinContext(new VarConfig().setPort(8088)));
+		filterCatcher = odinJector.getInstance(FilterCatcher.class);
+		launcher = odinJector.getInstance(Standalone.class);
+		launcher.configure(config -> {
+			config.addDefaultVarFilter(DefaultFilter1.class);
+			config.addDefaultVarFilter(DefaultFilter2.class);
+			config.configure(configInner -> {
+				configInner.configure(configFurtherIn -> {
+					// This filter should not be run for FilterControllerClass as it is in an inner configurataion
+					configFurtherIn.addDefaultVarFilter(ShouldNotBeRunFilterInner.class);
+				});
+				config.addDefaultVarFilter(DefaultFilter3.class);
+				config.addControllerPackage(FilterControllerClass.class.getPackage());
+				config.addDefaultVarFilter(DefaultFilter4.class);
+			});
+			config.configure(configOnTheSide -> {
+				// This filter should not be run for FilterControllerClass as it is in an configurataion next to
+				configOnTheSide.addDefaultVarFilter(ShouldNotBeRunFilterOnTheSide.class);
+			});
+		});
+		thread = new Thread(launcher);
+		thread.run();
+	}
+
+	@After
+	public void after() {
+		filterCatcher.getResult().clear();
+	}
+
+	@AfterClass
+	public static void teardown() {
+		launcher.stop();
+	}
+
+	@Test
+	public void fullFilterOrder() throws Throwable {
+		HttpURLConnection con = HttpClient.get("http://localhost:8088/filter-order", "");
+		HttpClient.readContent(con);
+		List<String> result = filterCatcher.getResult();
+		assertEquals("in;DefaultFilter1\n" +
+				"in;DefaultFilter2\n" +
+				"in;DefaultFilter3\n" +
+				"in;DefaultFilter4\n" +
+				"in;PackageFilter1\n" +
+				"in;PackageFilter2\n" +
+				"in;ClassFilter1\n" +
+				"in;ClassFilter2\n" +
+				"in;MethodFilter1\n" +
+				"in;MethodFilter2\n" +
+				"in;OverridingFilter\n" +
+				"controller\n" +
+				"out;OverridingFilter\n" +
+				"out;MethodFilter2\n" +
+				"out;MethodFilter1\n" +
+				"out;ClassFilter2\n" +
+				"out;ClassFilter1\n" +
+				"out;PackageFilter2\n" +
+				"out;PackageFilter1\n" +
+				"out;DefaultFilter4\n" +
+				"out;DefaultFilter3\n" +
+				"out;DefaultFilter2\n" +
+				"out;DefaultFilter1", String.join("\n", result));
+	}
+}


### PR DESCRIPTION
Filters should be ordered by:
 - default filters from outer configuration first (and not from configurations outside the scope of where the controller is configured)
 - package level filter annotattions
 - class level filter annotattions
 - method level filter annotattions

Filters should be overriding eachother if they have the same custom filter annotation and the same filter implementation.

Also, it should not matter in which order the methods in the configuration lambda is called. controllers should respect all configurations within the lambda, and hence should be evaluated last