### PR TITLE
streamlined content type handling

### DIFF
--- a/core/src/main/java/io/varhttp/ContentTypeException.java
+++ b/core/src/main/java/io/varhttp/ContentTypeException.java
@@ -1,0 +1,7 @@
+package io.varhttp;
+
+public class ContentTypeException extends RuntimeException {
+	public ContentTypeException(String s) {
+		super(s);
+	}
+}

--- a/core/src/main/java/io/varhttp/ContentTypes.java
+++ b/core/src/main/java/io/varhttp/ContentTypes.java
@@ -16,6 +16,9 @@ public class ContentTypes extends TreeSet<ContentTypes.ContentType> {
 	}
 
 	public void add(String types) {
+		if (types.isEmpty()) {
+			return;
+		}
 		Stream.of(types.split(",")).map(ContentType::new).forEach(this::add);
 	}
 
@@ -28,11 +31,6 @@ public class ContentTypes extends TreeSet<ContentTypes.ContentType> {
 			throw new ContentTypeException("Requested Content-Type is not supported");
 		}
 		return this.first();
-	}
-
-	public void set(String contentType) {
-		clear();
-		add(contentType);
 	}
 
 	public ContentTypes limitTo(List<String> types) throws ContentTypeException {

--- a/core/src/main/java/io/varhttp/ControllerContext.java
+++ b/core/src/main/java/io/varhttp/ControllerContext.java
@@ -6,7 +6,9 @@ import javax.servlet.http.HttpServletResponse;
 public class ControllerContext {
 	private final HttpServletRequest request;
 	private final HttpServletResponse response;
+	private final ContentTypes types = new ContentTypes();
 	private VarFilterChain filterChain;
+	private String contentType;
 
 	public ControllerContext(HttpServletRequest request, HttpServletResponse response) {
 		this.request = request;
@@ -21,6 +23,10 @@ public class ControllerContext {
 		return response;
 	}
 
+	public ContentTypes contentTypes() {
+		return types;
+	}
+
 	public RequestParameters getParameters() {
 		return new RequestParametersImplementation(request);
 	}
@@ -31,5 +37,13 @@ public class ControllerContext {
 
 	public void setFilterChain(VarFilterChain filterChain) {
 		this.filterChain = filterChain;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	public String getContentType() {
+		return contentType;
 	}
 }

--- a/core/src/main/java/io/varhttp/ControllerContext.java
+++ b/core/src/main/java/io/varhttp/ControllerContext.java
@@ -6,7 +6,7 @@ import javax.servlet.http.HttpServletResponse;
 public class ControllerContext {
 	private final HttpServletRequest request;
 	private final HttpServletResponse response;
-	private final ContentTypes types = new ContentTypes();
+	private final ContentTypes accepted = new ContentTypes();
 	private VarFilterChain filterChain;
 	private String contentType;
 
@@ -24,7 +24,7 @@ public class ControllerContext {
 	}
 
 	public ContentTypes acceptedTypes() {
-		return types;
+		return accepted;
 	}
 
 	public RequestParameters getParameters() {

--- a/core/src/main/java/io/varhttp/ControllerContext.java
+++ b/core/src/main/java/io/varhttp/ControllerContext.java
@@ -23,7 +23,7 @@ public class ControllerContext {
 		return response;
 	}
 
-	public ContentTypes contentTypes() {
+	public ContentTypes acceptedTypes() {
 		return types;
 	}
 

--- a/core/src/main/java/io/varhttp/ControllerExecution.java
+++ b/core/src/main/java/io/varhttp/ControllerExecution.java
@@ -11,7 +11,9 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.Method;
+import java.net.ConnectException;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -45,7 +47,16 @@ public class ControllerExecution  {
 			filters.add(filterExecution);
 			Iterator<Object> iterator = filters.iterator();
 			VarServletFilterChain chain = new VarServletFilterChain(context, iterator.next(), iterator);
+			if (context.response().getHeader("Content-Type") == null) {
+				Enumeration<String> acceptHeaders = context.request().getHeaders("Accept");
+				while (acceptHeaders.hasMoreElements()) {
+					context.contentTypes().add(acceptHeaders.nextElement());
+				}
+			}
+
 			chain.doFilter(context.request(), context.response());
+		} catch (ContentTypeException e) {
+			fail(415,e,context.response());
 		} catch (WrappedServletException e) {
 			// Controller logic threw exception
 			Throwable cause = e.getCause() == null ? e : e.getCause();

--- a/core/src/main/java/io/varhttp/ControllerExecution.java
+++ b/core/src/main/java/io/varhttp/ControllerExecution.java
@@ -4,14 +4,12 @@ import io.varhttp.parameterhandlers.IParameterHandler;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Provider;
-import javax.servlet.Filter;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.Method;
-import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -50,7 +48,7 @@ public class ControllerExecution  {
 			if (context.response().getHeader("Content-Type") == null) {
 				Enumeration<String> acceptHeaders = context.request().getHeaders("Accept");
 				while (acceptHeaders.hasMoreElements()) {
-					context.contentTypes().add(acceptHeaders.nextElement());
+					context.acceptedTypes().add(acceptHeaders.nextElement());
 				}
 			}
 

--- a/core/src/main/java/io/varhttp/ControllerExecution.java
+++ b/core/src/main/java/io/varhttp/ControllerExecution.java
@@ -45,12 +45,14 @@ public class ControllerExecution  {
 			filters.add(filterExecution);
 			Iterator<Object> iterator = filters.iterator();
 			VarServletFilterChain chain = new VarServletFilterChain(context, iterator.next(), iterator);
-			if (context.response().getHeader("Content-Type") == null) {
-				Enumeration<String> acceptHeaders = context.request().getHeaders("Accept");
-				while (acceptHeaders.hasMoreElements()) {
-					context.acceptedTypes().add(acceptHeaders.nextElement());
-				}
+			Enumeration<String> acceptHeaders = context.request().getHeaders("Accept");
+			while (acceptHeaders.hasMoreElements()) {
+				context.acceptedTypes().add(acceptHeaders.nextElement());
 			}
+			if (context.acceptedTypes().isEmpty()) {
+				context.acceptedTypes().add("*");
+			}
+
 
 			chain.doFilter(context.request(), context.response());
 		} catch (ContentTypeException e) {

--- a/core/src/main/java/io/varhttp/ControllerExecution.java
+++ b/core/src/main/java/io/varhttp/ControllerExecution.java
@@ -50,9 +50,8 @@ public class ControllerExecution  {
 				context.acceptedTypes().add(acceptHeaders.nextElement());
 			}
 			if (context.acceptedTypes().isEmpty()) {
-				context.acceptedTypes().add("*");
+				context.acceptedTypes().add("*/*");
 			}
-
 
 			chain.doFilter(context.request(), context.response());
 		} catch (ContentTypeException e) {

--- a/core/src/main/java/io/varhttp/ParameterHandler.java
+++ b/core/src/main/java/io/varhttp/ParameterHandler.java
@@ -49,9 +49,9 @@ public class ParameterHandler {
 		return args;
 	}
 
-	public void handleReturnResponse(Object response, ControllerContext context, ContentTypes types) {
+	public void handleReturnResponse(Object response, ControllerContext context) {
 		if (response != null && !(response instanceof Void)) {
-			new VarResponseStream(context.response(), serializer).setTypes(types).write(response);
+			new VarResponseStream(context, serializer).write(response);
 		}
 	}
 

--- a/core/src/main/java/io/varhttp/ResponseHeader.java
+++ b/core/src/main/java/io/varhttp/ResponseHeader.java
@@ -58,7 +58,5 @@ public interface ResponseHeader {
 	 */
 	void redirect(URL url);
 
-	default void setContentType(String s) {
-		setHeader("Content-Type", s);
-	}
+	void setContentType(String s);
 }

--- a/core/src/main/java/io/varhttp/VarFilterExecution.java
+++ b/core/src/main/java/io/varhttp/VarFilterExecution.java
@@ -50,17 +50,12 @@ public class VarFilterExecution {
 			if (!containsChain && context.getFilterChain() != null) {
 				context.getFilterChain().proceed();
 			}
-			ContentTypes types = new ContentTypes();
 
-			if (context.response().getHeader("Content-Type") == null) {
-				if (context.request().getHeader("Accept") != null) {
-					types.add(context.request().getHeader("Accept"));
-				}
-				if (!"".equals(matchResult.getContentType())) {
-					types.set(matchResult.getContentType());
-				}
+			if (!"".equals(matchResult.getContentType())) {
+				context.setContentType(matchResult.getContentType());
 			}
-			parameterHandler.handleReturnResponse(responseObject, context, types);
+
+			parameterHandler.handleReturnResponse(responseObject, context);
 
 		} catch (ServletException|IOException|RuntimeException e) {
 			throw e;

--- a/core/src/main/java/io/varhttp/VarResponseHeader.java
+++ b/core/src/main/java/io/varhttp/VarResponseHeader.java
@@ -16,18 +16,26 @@ public class VarResponseHeader implements ResponseHeader {
 	}
 
 	@Override
-	public void setStatus(int httpResonseCode) {
-		response.setStatus(httpResonseCode);
+	public void setStatus(int httpResponseCode) {
+		response.setStatus(httpResponseCode);
 	}
 
 	@Override
 	public void addHeader(String name, String value) {
-		response.addHeader(name, value);
+		if ("Content-Type".equalsIgnoreCase(name)) {
+			setContentType(value);
+		} else {
+			response.addHeader(name, value);
+		}
 	}
 
 	@Override
 	public void setHeader(String name, String value) {
-		response.setHeader(name, value);
+		if ("Content-Type".equalsIgnoreCase(name)) {
+			setContentType(value);
+		} else {
+			response.setHeader(name, value);
+		}
 	}
 
 	@Override

--- a/core/src/main/java/io/varhttp/VarResponseHeader.java
+++ b/core/src/main/java/io/varhttp/VarResponseHeader.java
@@ -7,9 +7,11 @@ import javax.servlet.http.HttpServletResponse;
 public class VarResponseHeader implements ResponseHeader {
 	private final HttpServletResponse response;
 	private final String classPath;
+	private final ControllerContext context;
 
-	public VarResponseHeader(HttpServletResponse response, String classPath) {
-		this.response = response;
+	public VarResponseHeader(ControllerContext controllerContext, String classPath) {
+		this.response = controllerContext.response();
+		this.context = controllerContext;
 		this.classPath = classPath;
 	}
 
@@ -46,5 +48,10 @@ public class VarResponseHeader implements ResponseHeader {
 	@Override
 	public void addCookie(Cookie cookie) {
 		this.response.addCookie(cookie);
+	}
+
+	@Override
+	public void setContentType(String s) {
+		context.setContentType(s);
 	}
 }

--- a/core/src/main/java/io/varhttp/VarResponseStream.java
+++ b/core/src/main/java/io/varhttp/VarResponseStream.java
@@ -24,7 +24,7 @@ public class VarResponseStream implements ResponseStream {
 	@Override
 	public BufferedWriter getContentWriter(String fileName, String contentType, Charset charset) {
 		response.addHeader("Content-Disposition", "attachment; filename=\"" + fileName + '"');
-		response.setContentType(contentType);
+		response.setContentType(context.acceptedTypes().limitTo(contentType).getHighestPriority().getType());
 		response.setCharacterEncoding(charset.name());
 		try {
 			return new BufferedWriter(new OutputStreamWriter(new BufferedOutputStream(response.getOutputStream()), charset));
@@ -35,7 +35,7 @@ public class VarResponseStream implements ResponseStream {
 
 	@Override
 	public OutputStream getOutputStream(String contentType, Charset charset) {
-		response.setContentType(contentType);
+		response.setContentType(context.acceptedTypes().limitTo(contentType).getHighestPriority().getType());
 		if(charset != null) {
 			response.setCharacterEncoding(charset.name());
 		}

--- a/core/src/main/java/io/varhttp/parameterhandlers/ResponseHeaderParameterHandler.java
+++ b/core/src/main/java/io/varhttp/parameterhandlers/ResponseHeaderParameterHandler.java
@@ -15,7 +15,7 @@ public class ResponseHeaderParameterHandler implements IParameterHandlerMatcher 
 	@Override
 	public IParameterHandler getHandlerIfMatches(Method method, Parameter parameter, String path, String classPath) {
 		if (ResponseHeader.class == parameter.getType()) {
-			return context -> new VarResponseHeader(context.response(), classPath);
+			return context -> new VarResponseHeader(context, classPath);
 		}
 		return null;
 	}

--- a/core/src/main/java/io/varhttp/parameterhandlers/ResponseStreamParameterHandler.java
+++ b/core/src/main/java/io/varhttp/parameterhandlers/ResponseStreamParameterHandler.java
@@ -24,7 +24,7 @@ public class ResponseStreamParameterHandler implements IParameterHandlerMatcher 
 	@Override
 	public IParameterHandler getHandlerIfMatches(Method method, Parameter parameter, String path, String classPath) {
 		if (ResponseStream.class == parameter.getType()) {
-			return context ->  new VarResponseStream(context.response(), serializer);
+			return context ->  new VarResponseStream(context, serializer);
 		}
 		return null;
 	}

--- a/core/src/test/java/io/varhttp/ContentTypesTest.java
+++ b/core/src/test/java/io/varhttp/ContentTypesTest.java
@@ -41,6 +41,24 @@ public class ContentTypesTest {
 		assertEquals("application/signed-exchange", type.getType());
 	}
 
+	@Test
+	public void limitedTo_happy() {
+		contentTypes.add("text/html; q=1.0, image/gif; q=0.6, image/jpeg; q=0.6, image/*; q=0.5");
 
+		assertEquals("text/html", contentTypes.limitTo("text/html").getHighestPriority().getType());
+	}
 
+	@Test
+	public void limitedTo_partialMatch() {
+		contentTypes.add("text/html; q=1.0, text/*; q=0.8, image/gif; q=0.6, image/jpeg; q=0.6, image/*; q=0.5");
+
+		assertEquals("text/plain", contentTypes.limitTo("text/plain").getHighestPriority().getType());
+	}
+
+	@Test
+	public void limitedTo_completeWildcard() {
+		contentTypes.add("text/html; q=1.0, text/*; q=0.8, image/gif; q=0.6, image/jpeg; q=0.6, image/*; q=0.5, */*; q=0.1");
+
+		assertEquals("my/custom", contentTypes.limitTo("my/custom").getHighestPriority().getType());
+	}
 }

--- a/test/src/test/java/io/varhttp/LauncherTest.java
+++ b/test/src/test/java/io/varhttp/LauncherTest.java
@@ -56,6 +56,16 @@ public class LauncherTest {
 	}
 
 	@Test
+	public void notSettingAcceptHeaderContentType_willFallbackToServerDefault() throws Throwable {
+		HttpURLConnection con = HttpClient.get("http://localhost:8088/my-test", "");
+		con.setRequestProperty("Accept", "");
+
+		HttpClient.readContent(con);
+		Map<String, List<String>> headers = HttpClient.readHeaders(con);
+		assertEquals("text/plain", headers.get("Content-type").get(0));
+	}
+
+	@Test
 	public void pathVariable() throws Throwable {
 		HttpURLConnection con = HttpClient.get("http://localhost:8088/pathVar/my-string", "");
 

--- a/test/src/test/java/io/varhttp/LauncherTest.java
+++ b/test/src/test/java/io/varhttp/LauncherTest.java
@@ -5,6 +5,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Map;
@@ -36,9 +37,22 @@ public class LauncherTest {
 		Map<String, List<String>> headers = HttpClient.readHeaders(con);
 
 		assertTrue(headers.containsKey("Content-type"));
-		assertEquals(headers.get("Content-type").get(0), "text/plain");
+		assertEquals("text/plain", headers.get("Content-type").get(0));
 
 		assertEquals("Simple string", content.toString());
+	}
+
+	@Test
+	public void requestingUnsupportedContentType() throws Throwable {
+		HttpURLConnection con = HttpClient.get("http://localhost:8088/my-test", "");
+		con.setRequestProperty("Accept", "my/custom");
+
+		try {
+			HttpClient.readContent(con);
+			fail();
+		} catch (IOException e) {
+			assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 415"));
+		}
 	}
 
 	@Test
@@ -374,7 +388,7 @@ public class LauncherTest {
 		assertEquals("{\"string\":\"Simple string\"}", content.toString());
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void serializedReturnObject_toAcceptedContentType_unsupportedType() throws Throwable {
 		HttpURLConnection con = HttpClient.get("http://localhost:8088/my-test-serialized", "");
 		con.setRequestProperty("Accept", "text/xml");


### PR DESCRIPTION
1) if content type served by controller is not accepted by requester, throw 415 http code
2) Moved content type handling into ContentTypes
3) Instead of setting the content type directly on the header, set it on the context, so it can do content type negotiation based on that.