### PR TITLE
SAGA-7353: Redirect requests based on simple fixed paths.

### DIFF
--- a/var-core/src/main/java/io/varhttp/VarConfiguration.java
+++ b/var-core/src/main/java/io/varhttp/VarConfiguration.java
@@ -92,4 +92,8 @@ public class VarConfiguration {
 	public void onControllerAdd(ControllerListener methodConsumer) {
 		context.onControllerAdd(methodConsumer);
 	}
+
+	public void addRedirect(String from, String to) {
+		context.addRedirect(from, to);
+	}
 }

--- a/var-core/src/main/java/io/varhttp/VarConfigurationContext.java
+++ b/var-core/src/main/java/io/varhttp/VarConfigurationContext.java
@@ -97,6 +97,10 @@ public class VarConfigurationContext {
 		}
 	}
 
+	public void addRedirect(String from, String to) {
+		varServlet.redirect(from, to);
+	}
+
 	private List<Object> getFilters(Method method) {
 		LinkedHashSet<FilterTuple> filters = new LinkedHashSet<>();
 		replaceAll(filters, getFilterAnnotations(method.getDeclaringClass().getPackage().getAnnotations()));

--- a/var-core/src/main/java/io/varhttp/VarServlet.java
+++ b/var-core/src/main/java/io/varhttp/VarServlet.java
@@ -70,7 +70,7 @@ public class VarServlet extends HttpServlet {
 		Request r = new Request(httpMethod, servletPath);
 
 		final String[] requestPath;
-		if(redirects.containsKey(r.path)) {
+		if (redirects.containsKey(r.path)) {
 			requestPath = redirects.get(r.path).substring(1).split("/");
 		} else {
 			requestPath = r.path.substring(1).split("/");

--- a/var-core/src/main/java/io/varhttp/VarServlet.java
+++ b/var-core/src/main/java/io/varhttp/VarServlet.java
@@ -82,9 +82,7 @@ public class VarServlet extends HttpServlet {
 
 		if (exe != null) {
 			try {
-
 				exe.execute(new ControllerContext(request, response));
-
 			} catch (Exception e) {
 				logger.error("Execution failed: " + e.getMessage(), e);
 				response.setStatus(500);
@@ -103,7 +101,6 @@ public class VarServlet extends HttpServlet {
 			throw new RuntimeException(e);
 		}
 	}
-
 
 	public void configure(Consumer<VarConfiguration> configuration) {
 		VarConfiguration varConfiguration = new VarConfiguration(this, controllerMapper, baseConfigurationContext, parameterHandler);

--- a/var-core/src/main/java/io/varhttp/VarServlet.java
+++ b/var-core/src/main/java/io/varhttp/VarServlet.java
@@ -1,13 +1,14 @@
 package io.varhttp;
 
-import java.io.IOException;
-import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.function.Consumer;
 
 public class VarServlet extends HttpServlet {
 	private final BaseVarConfigurationContext baseConfigurationContext;
@@ -15,6 +16,7 @@ public class VarServlet extends HttpServlet {
 	private final ParameterHandler parameterHandler;
 	final ExecutionMap executions;
 	private ControllerMapper controllerMapper;
+	private HashMap<String, String> redirects = new HashMap<>();
 
 	public VarServlet(ParameterHandler parameterHandler, ControllerMapper controllerMapper, ObjectFactory objectFactory, ControllerFilter controllerFilter) {
 		this.parameterHandler = parameterHandler;
@@ -67,7 +69,12 @@ public class VarServlet extends HttpServlet {
 		}
 		Request r = new Request(httpMethod, servletPath);
 
-		final String[] requestPath = r.path.substring(1).split("/");
+		final String[] requestPath;
+		if(redirects.containsKey(r.path)) {
+			requestPath = redirects.get(r.path).substring(1).split("/");
+		} else {
+			requestPath = r.path.substring(1).split("/");
+		}
 
 		ControllerExecution exe = null;
 
@@ -75,9 +82,11 @@ public class VarServlet extends HttpServlet {
 
 		if (exe != null) {
 			try {
+
 				exe.execute(new ControllerContext(request, response));
+
 			} catch (Exception e) {
-				logger.error("Execution failed: "+e.getMessage(), e);
+				logger.error("Execution failed: " + e.getMessage(), e);
 				response.setStatus(500);
 				return;
 			}
@@ -95,10 +104,15 @@ public class VarServlet extends HttpServlet {
 		}
 	}
 
+
 	public void configure(Consumer<VarConfiguration> configuration) {
 		VarConfiguration varConfiguration = new VarConfiguration(this, controllerMapper, baseConfigurationContext, parameterHandler);
 		configuration.accept(varConfiguration);
 		baseConfigurationContext.applyMappings();
 		varConfiguration.applyMappings();
+	}
+
+	public void redirect(String from, String to) {
+		redirects.put(from, to);
 	}
 }

--- a/var-core/src/test/java/io/varhttp/VarServletTest.java
+++ b/var-core/src/test/java/io/varhttp/VarServletTest.java
@@ -174,8 +174,7 @@ public class VarServletTest {
 		CountDownLatch latch = new CountDownLatch(1);
 		doAnswer(invocation -> {
 			ControllerContext context = (ControllerContext) invocation.getArguments()[0];
-			if (context.getParameters().get("param1").equals("value1") &&
-					context.getParameters().get("param2").equals("value2")) {
+			if (context.getParameters().get("param1").equals("value1") && context.getParameters().get("param2").equals("value2")) {
 				latch.countDown();
 			}
 			return null;

--- a/var-core/src/test/java/io/varhttp/VarServletTest.java
+++ b/var-core/src/test/java/io/varhttp/VarServletTest.java
@@ -9,6 +9,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import javax.servlet.ServletOutputStream;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.*;
 
@@ -151,7 +152,7 @@ public class VarServletTest {
 	}
 
 	@Test
-	public void handleGet_withRedirectAndQueryString_queryStringIsPreserved() throws IOException {
+	public void handleGet_withRedirectAndQueryString_queryStringIsPreserved() throws IOException, InterruptedException {
 		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
 		when(request.getMethod()).thenReturn("GET");
 		when(request.getPathInfo()).thenReturn("/redirected-test");
@@ -184,6 +185,8 @@ public class VarServletTest {
 
 		servlet.doGet(request, response);
 
+		//noinspection ResultOfMethodCallIgnored Ignored since we only care if it fails
+		latch.await(100, TimeUnit.MILLISECONDS);
 
 		verify(usedController, times(1)).execute(any());
 		verify(unusedController, never()).execute(any());

--- a/var-core/src/test/java/io/varhttp/VarServletTest.java
+++ b/var-core/src/test/java/io/varhttp/VarServletTest.java
@@ -3,17 +3,18 @@ package io.varhttp;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import javax.servlet.ServletOutputStream;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
-import static org.hamcrest.CoreMatchers.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VarServletTest {
@@ -124,7 +125,7 @@ public class VarServletTest {
 	}
 
 	@Test
-	public void handleGet_withRedirectAndQueryString_queryStringIsIgnored() throws IOException {
+	public void handleGet_withRedirectAndQueryString_queryStringDoesNotAffectRedirecting() throws IOException {
 		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
 		when(request.getMethod()).thenReturn("GET");
 		when(request.getPathInfo()).thenReturn("/redirected-test");
@@ -147,6 +148,46 @@ public class VarServletTest {
 		servlet.redirect("/redirected-test", "/test");
 
 		servlet.doGet(request, response);
+
+		verify(usedController, times(1)).execute(any());
+		verify(unusedController, never()).execute(any());
+		verify(response, times(0)).setStatus(404);
+	}
+
+	@Test
+	public void handleGet_withRedirectAndQueryString_queryStringIsPreserved() throws IOException {
+		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
+		when(request.getMethod()).thenReturn("GET");
+		when(request.getPathInfo()).thenReturn("/redirected-test");
+		when(request.getQueryString()).thenReturn("param1=value1&param2=value2");
+		when(request.getContentType()).thenReturn("application/json");
+		when(request.getCharacterEncoding()).thenReturn("UTF-8");
+		when(request.getServletPath()).thenReturn("");
+		when(request.getContextPath()).thenReturn("");
+		when(request.getRequestURI()).thenReturn("/redirected-test");
+		when(request.getRequestURL()).thenReturn(new StringBuffer("/redirected-test"));
+		VarHttpServletResponse response = mock(VarHttpServletResponse.class);
+
+		ControllerExecution usedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/test"), usedController);
+		ControllerExecution unusedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/other"), unusedController);
+
+		when(response.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
+		CountDownLatch latch = new CountDownLatch(1);
+		doAnswer(invocation -> {
+			ControllerContext context = (ControllerContext) invocation.getArguments()[0];
+			if(context.getParameters().get("param1").equals("value1") &&
+					context.getParameters().get("param2").equals("value2")) {
+				latch.countDown();
+			}
+			return null;
+		}).when(usedController).execute(any());
+
+		servlet.redirect("/redirected-test", "/test");
+
+		servlet.doGet(request, response);
+
 
 		verify(usedController, times(1)).execute(any());
 		verify(unusedController, never()).execute(any());

--- a/var-core/src/test/java/io/varhttp/VarServletTest.java
+++ b/var-core/src/test/java/io/varhttp/VarServletTest.java
@@ -1,0 +1,156 @@
+package io.varhttp;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.ServletOutputStream;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+import static org.hamcrest.CoreMatchers.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VarServletTest {
+
+	private VarServlet servlet;
+	@Mock
+	private ParameterHandler parameterHandler;
+	@Mock
+	private ControllerMapper controllerMapper;
+	@Mock
+	private ObjectFactory objectFactory;
+	@Mock
+	private ControllerFilter controllerFilter;
+	@Mock
+	private VarConfigurationContext context;
+
+	@Before
+	public void setup() {
+		servlet = new VarServlet(parameterHandler, controllerMapper, objectFactory, controllerFilter);
+	}
+
+	@Test
+	public void handleGet_happyPath() throws IOException {
+		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
+		when(request.getMethod()).thenReturn("GET");
+		when(request.getPathInfo()).thenReturn("/test");
+		when(request.getQueryString()).thenReturn("");
+		when(request.getContentType()).thenReturn("application/json");
+		when(request.getCharacterEncoding()).thenReturn("UTF-8");
+		when(request.getServletPath()).thenReturn("");
+		when(request.getContextPath()).thenReturn("");
+		when(request.getRequestURI()).thenReturn("/test");
+		when(request.getRequestURL()).thenReturn(new StringBuffer("/test"));
+		VarHttpServletResponse response = mock(VarHttpServletResponse.class);
+
+		ControllerExecution usedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/test"), usedController);
+		ControllerExecution unusedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/other"), unusedController);
+
+		when(response.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
+
+		servlet.doGet(request, response);
+
+		verify(usedController, times(1)).execute(any());
+		verify(unusedController, never()).execute(any());
+		verify(response, times(0)).setStatus(404);
+	}
+
+	@Test
+	public void handleGet_withRedirect_happyPath() throws IOException {
+		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
+		when(request.getMethod()).thenReturn("GET");
+		when(request.getPathInfo()).thenReturn("/redirected-test");
+		when(request.getQueryString()).thenReturn("");
+		when(request.getContentType()).thenReturn("application/json");
+		when(request.getCharacterEncoding()).thenReturn("UTF-8");
+		when(request.getServletPath()).thenReturn("");
+		when(request.getContextPath()).thenReturn("");
+		when(request.getRequestURI()).thenReturn("/redirected-test");
+		when(request.getRequestURL()).thenReturn(new StringBuffer("/redirected-test"));
+		VarHttpServletResponse response = mock(VarHttpServletResponse.class);
+
+		ControllerExecution usedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/test"), usedController);
+		ControllerExecution unusedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/other"), unusedController);
+
+		when(response.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
+
+		servlet.redirect("/redirected-test", "/test");
+
+		servlet.doGet(request, response);
+
+		verify(usedController, times(1)).execute(any());
+		verify(unusedController, never()).execute(any());
+		verify(response, times(0)).setStatus(404);
+	}
+
+	@Test
+	public void handleGet_withRedirect_toUnregisteredEndpoint() throws IOException {
+		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
+		when(request.getMethod()).thenReturn("GET");
+		when(request.getPathInfo()).thenReturn("/redirected-test");
+		when(request.getQueryString()).thenReturn("");
+		when(request.getContentType()).thenReturn("application/json");
+		when(request.getCharacterEncoding()).thenReturn("UTF-8");
+		when(request.getServletPath()).thenReturn("");
+		when(request.getContextPath()).thenReturn("");
+		when(request.getRequestURI()).thenReturn("/redirected-test");
+		when(request.getRequestURL()).thenReturn(new StringBuffer("/redirected-test"));
+		VarHttpServletResponse response = mock(VarHttpServletResponse.class);
+
+		ControllerExecution usedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/test"), usedController);
+		ControllerExecution unusedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/other"), unusedController);
+
+		when(response.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
+
+		servlet.redirect("/redirected-test", "/unregistered");
+
+		servlet.doGet(request, response);
+
+		verify(usedController, never()).execute(any());
+		verify(unusedController, never()).execute(any());
+		verify(response, times(1)).setStatus(404);
+	}
+
+	@Test
+	public void handlePost_withRedirect_happyPath() throws IOException {
+		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
+		when(request.getMethod()).thenReturn("POST");
+		when(request.getPathInfo()).thenReturn("/redirected-test");
+		when(request.getQueryString()).thenReturn("");
+		when(request.getContentType()).thenReturn("application/json");
+		when(request.getCharacterEncoding()).thenReturn("UTF-8");
+		when(request.getServletPath()).thenReturn("");
+		when(request.getContextPath()).thenReturn("");
+		when(request.getRequestURI()).thenReturn("/redirected-test");
+		when(request.getRequestURL()).thenReturn(new StringBuffer("/redirected-test"));
+		VarHttpServletResponse response = mock(VarHttpServletResponse.class);
+
+		ControllerExecution usedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.POST, "/test"), usedController);
+		ControllerExecution unusedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.POST, "/other"), unusedController);
+
+		when(response.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
+
+		servlet.redirect("/redirected-test", "/test");
+
+		servlet.doPost(request, response);
+
+		verify(usedController, times(1)).execute(any());
+		verify(unusedController, never()).execute(any());
+		verify(response, times(0)).setStatus(404);
+	}
+
+}

--- a/var-core/src/test/java/io/varhttp/VarServletTest.java
+++ b/var-core/src/test/java/io/varhttp/VarServletTest.java
@@ -124,6 +124,36 @@ public class VarServletTest {
 	}
 
 	@Test
+	public void handleGet_withRedirectAndQueryString_queryStringIsIgnored() throws IOException {
+		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
+		when(request.getMethod()).thenReturn("GET");
+		when(request.getPathInfo()).thenReturn("/redirected-test");
+		when(request.getQueryString()).thenReturn("param1=value1&param2=value2");
+		when(request.getContentType()).thenReturn("application/json");
+		when(request.getCharacterEncoding()).thenReturn("UTF-8");
+		when(request.getServletPath()).thenReturn("");
+		when(request.getContextPath()).thenReturn("");
+		when(request.getRequestURI()).thenReturn("/redirected-test");
+		when(request.getRequestURL()).thenReturn(new StringBuffer("/redirected-test"));
+		VarHttpServletResponse response = mock(VarHttpServletResponse.class);
+
+		ControllerExecution usedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/test"), usedController);
+		ControllerExecution unusedController = mock(ControllerExecution.class);
+		servlet.executions.put(context, new Request(HttpMethod.GET, "/other"), unusedController);
+
+		when(response.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
+
+		servlet.redirect("/redirected-test", "/test");
+
+		servlet.doGet(request, response);
+
+		verify(usedController, times(1)).execute(any());
+		verify(unusedController, never()).execute(any());
+		verify(response, times(0)).setStatus(404);
+	}
+
+	@Test
 	public void handlePost_withRedirect_happyPath() throws IOException {
 		VarHttpServletRequest request = mock(VarHttpServletRequest.class);
 		when(request.getMethod()).thenReturn("POST");

--- a/var-core/src/test/java/io/varhttp/VarServletTest.java
+++ b/var-core/src/test/java/io/varhttp/VarServletTest.java
@@ -4,16 +4,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 import javax.servlet.ServletOutputStream;
-
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -177,7 +173,7 @@ public class VarServletTest {
 		CountDownLatch latch = new CountDownLatch(1);
 		doAnswer(invocation -> {
 			ControllerContext context = (ControllerContext) invocation.getArguments()[0];
-			if(context.getParameters().get("param1").equals("value1") &&
+			if (context.getParameters().get("param1").equals("value1") &&
 					context.getParameters().get("param2").equals("value2")) {
 				latch.countDown();
 			}
@@ -223,5 +219,4 @@ public class VarServletTest {
 		verify(unusedController, never()).execute(any());
 		verify(response, times(0)).setStatus(404);
 	}
-
 }


### PR DESCRIPTION
TODO:
 - Does not yet work with requests that rely on client-side changes to the URL, e.g. frontend pages, as the request is transparently redirected. Not sure if it ever will?
 - Does not work with paths that use path parameters, e.g. /api/extension/getInfo/123/ will not be redirectable, but neither will /api/extension/getInfo/*, with the current system
 - Its just really crude in general.

I think this should be enough for what we need it for SAGA-7353 through, as we just want to redirect some fairly static endpoints