### PR TITLE
SAGA-7517: Upgrade to latest 2.2 patch version of undertow

### DIFF
--- a/var-undertow/build.gradle
+++ b/var-undertow/build.gradle
@@ -1,14 +1,14 @@
 dependencies {
 // https://mvnrepository.com/artifact/io.undertow/undertow-core
-    api('io.undertow:undertow-core:2.2.18.Final') {
+    api('io.undertow:undertow-core:2.2.26.Final') {
         exclude group: 'org.wildfly.client', module: 'wildfly-client-config'
     }
 // https://mvnrepository.com/artifact/io.undertow/undertow-servlet
-    api(group: 'io.undertow', name: 'undertow-servlet', version: '2.2.18.Final') {
+    api(group: 'io.undertow', name: 'undertow-servlet', version: '2.2.26.Final') {
         exclude group: 'org.wildfly.client', module: 'wildfly-client-config'
     }
 // https://mvnrepository.com/artifact/io.undertow/undertow-websockets-jsr
-    api(group: 'io.undertow', name: 'undertow-websockets-jsr', version: '2.2.18.Final') {
+    api(group: 'io.undertow', name: 'undertow-websockets-jsr', version: '2.2.26.Final') {
         exclude group: 'org.wildfly.client', module: 'wildfly-client-config'
     }
     api project(':var-core')


### PR DESCRIPTION
This fixes *most* of the known CVE's in the transitive dependencies, except for a minor one.

Would upgrade to 2.3, but unfortunately that breaks binary compatibility AND potentially also causes compile-time errors further up the chain, as a bunch of stuff was moved from javax to jakarta (they are the same thing, someone just decided to change package names...)